### PR TITLE
Update to be compatible with webpack 2

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,6 @@ module.exports = function (content) {
   this.cacheable();
   if (!hasModule(content)) return content;
 
-  return `module.id = "${this.resourcePath}"; ${content}`;
+  return `module.id = "${this.resourcePath}"; ${content.replace('module.id', 'module.i')}`;
 };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auto-module-name-loader",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Overwrites module id with module name in webpack module magic object",
   "keywords": [
     "webpack",


### PR DESCRIPTION
Webpack 2 now replaces module.id with module.i, don't know why, but we also have now to replace on the contents of the file so everything may keep working well

I've tried choosing another name like `webpack.custom` but then other crazy errors happened